### PR TITLE
Simplified CritItem.CanHaveCrits

### DIFF
--- a/Common/Globals/CritItem.cs
+++ b/Common/Globals/CritItem.cs
@@ -211,7 +211,7 @@ namespace CritRework.Common.Globals
 
         public static bool CanHaveCrits(Item item)
         {
-            return item.DamageType != DamageClass.Summon && item.DamageType != DamageClass.SummonMeleeSpeed && item.ammo == AmmoID.None && !item.consumable && !item.accessory && item.damage > 0;
+            return item.DamageType.UseStandardCritCalcs && item.useStyle != ItemUseStyleID.None && !item.consumable && item.damage > 0;
         }
 
         public override void ModifyTooltips(Item item, List<TooltipLine> tooltips)


### PR DESCRIPTION
In rare circumstances a weapon might be ammo, and in pretty ordinary circumstances someone might override UseStandardCritCalcs in a modded damage class.